### PR TITLE
Fix for "(__TEMPLATE__)" filename in backtrace.

### DIFF
--- a/lib/frank/base.rb
+++ b/lib/frank/base.rb
@@ -185,10 +185,12 @@ module Frank
 
     # render a page using tilt and get the result template markup back
     def tilt(page, ext, source, locals={}, &block)
-      Tilt[ext].new do
-        source = source.to_str if source.respond_to?(:to_str)
-        if source.match(/^[^\n]+$/) && File.exist?(source)
-          File.read(source)
+      source = source.to_str if source.respond_to?(:to_str)
+      filename = source if source.match(/^[^\n]+$/) && File.exist?(source)
+
+      Tilt[ext].new(filename) do
+        if filename
+          File.read(filename)
         else
           source
         end


### PR DESCRIPTION
If an error is raised during compilation of a layout by tilt, the file name will show up as "(**TEMPLATE**)" in the backtrace.

With this patch the file name (if there is any) is given to tilt upon execution, allowing it to use it in the backtrace.

Note: Tested with MRI 1.9.1, tilt 0.9, frank 1.0.6.
