### PR TITLE
Export to 'export/' by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,9 @@ When you're done working:
 
     $ frank export <export_dir>
 
-to compile templates and copy them--along with static your assets--into `<export_dir>`. Or,
+to compile templates and copy them--along with static your assets--into `<export_dir>` (or to `export/` if you don't specify an `<export_dir>`).
+
+Or,
 
     $ frank export --production <export_dir>
 

--- a/lib/frank/cli.rb
+++ b/lib/frank/cli.rb
@@ -123,10 +123,9 @@ module Frank
           Frank.new
         when 'export', 'e', 'out'
           # compile the project
-          print_usage_and_exit! unless ARGV[1]
           Frank.exporting!
           Frank.production! if @options[:production]
-          Frank.export.path = ARGV[1]
+          Frank.export.path = ARGV[1] if ARGV[1]
           Frank::Compile.export!
         when 'publish', 'p'
           # compile the project and scp it to server

--- a/lib/frank/settings.rb
+++ b/lib/frank/settings.rb
@@ -34,7 +34,7 @@ module Frank
 
       # export settings
       @export = OpenStruct.new
-      @export.path = nil
+      @export.path = "export"
       @export.silent = false
 
       # publish options

--- a/lib/template/setup.rb
+++ b/lib/template/setup.rb
@@ -43,6 +43,13 @@ Frank.dynamic_folder = "dynamic"
 Frank.layouts_folder = "layouts"
 
 # ----------------------
+# Export settings:
+#
+# Projects will be exported to default to the following directory
+#
+Frank.export.path = "export"
+
+# ----------------------
 #  Publish settings:
 #
 #  Frank can publish your exported project to

--- a/spec/compile_spec.rb
+++ b/spec/compile_spec.rb
@@ -4,6 +4,26 @@ describe Frank::Compile do
   include Rack::Test::Methods
 
   context 'default output' do
+    context 'without specifying an export dir' do
+
+      bin_dir    = File.join(File.dirname(File.dirname(__FILE__)), 'bin')
+      command    = File.join(bin_dir, 'frank export')
+      proj_dir   = File.join(File.dirname(__FILE__), 'template')
+      export_dir = File.join(proj_dir, 'export')
+
+      after do
+        FileUtils.rm_r export_dir
+      end
+
+      it 'creates the default export dir' do
+        Dir.chdir proj_dir do
+          system "#{command} > /dev/null"
+
+          File.directory?(export_dir).should be_true
+        end
+      end
+    end
+
     before :all do
       bin_dir    = File.join(File.dirname(File.dirname(__FILE__)), 'bin', 'frank export')
       proj_dir   = File.join(File.dirname(__FILE__), 'template')


### PR DESCRIPTION
Always thought this would be a useful feature, so I coded it myself.

The spec example doesn't fit that well in the group, but fixing that would have required a general overhaul so I decided to just put it at the top.

Hope you like it :)
