### PR TITLE
Added publishing via ftp and sftp (and ftp over tls)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,13 @@
+PATH
+  remote: .
+  specs:
+    frank (1.0.9)
+      haml (~> 3.0)
+      mongrel (~> 1.2.0.pre2)
+      net-ssh (~> 2.0)
+      rack (~> 1.1)
+      tilt (~> 1.3)
+
 GEM
   remote: http://rubygems.org/
   specs:
@@ -10,7 +20,6 @@ GEM
     coffee-script-source (1.1.2)
     compass (0.10.2)
       haml (>= 3.0.4)
-    contest (0.1.2)
     daemons (1.0.10)
     diff-lcs (1.1.2)
     erubis (2.6.6)
@@ -18,26 +27,24 @@ GEM
     execjs (1.2.4)
       multi_json (~> 1.0)
     gem_plugin (0.2.3)
-    gemcutter (0.6.1)
-    git (1.2.5)
     haml (3.0.13)
-    jeweler (1.4.0)
-      gemcutter (>= 0.1.0)
-      git (>= 1.2.5)
-      rubyforge (>= 2.0.0)
-    json_pure (1.4.3)
     less (1.2.21)
       mutter (>= 0.4.2)
       treetop (>= 1.4.2)
     liquid (2.1.2)
+    metaclass (0.0.1)
+    mocha (0.10.5)
+      metaclass (~> 0.0.1)
     mongrel (1.2.0.pre2)
       daemons (~> 1.0.10)
       gem_plugin (~> 0.2.3)
     multi_json (1.0.3)
     mutter (0.5.3)
-    net-scp (1.0.1)
+    net-scp (1.0.4)
       net-ssh (>= 1.99.1)
-    net-ssh (2.0.23)
+    net-sftp (2.0.5)
+      net-ssh (>= 2.0.9)
+    net-ssh (2.3.0)
     polyglot (0.3.1)
     rack (1.2.1)
     rack-test (0.5.4)
@@ -52,8 +59,6 @@ GEM
     rspec-expectations (2.6.0)
       diff-lcs (~> 1.1.2)
     rspec-mocks (2.6.0)
-    rubyforge (2.0.4)
-      json_pure (>= 1.1.7)
     tilt (1.3.3)
     treetop (1.4.8)
       polyglot (>= 0.3.1)
@@ -66,18 +71,14 @@ DEPENDENCIES
   builder
   coffee-script (~> 2.2.0)
   compass (~> 0.10.2)
-  contest
   erubis
-  haml (~> 3.0)
-  jeweler
+  frank!
   less
   liquid
-  mongrel (~> 1.2.0.pre2)
-  net-scp (~> 1.0)
-  net-ssh (~> 2.0)
-  rack (~> 1.1)
+  mocha
+  net-scp
+  net-sftp
   rack-test (~> 0.5)
   rake
   rdiscount
   rspec (~> 2.6.0)
-  tilt (~> 1.3)

--- a/Rakefile
+++ b/Rakefile
@@ -1,1 +1,8 @@
 require 'bundler/gem_tasks'
+require 'rspec/core/rake_task'
+
+desc "Run all specs"
+RSpec::Core::RakeTask.new do |t|
+  t.name = :tests
+  t.pattern = "spec/**/*_spec.rb"
+end

--- a/frank.gemspec
+++ b/frank.gemspec
@@ -16,18 +16,18 @@ Gem::Specification.new do |s|
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
-  
+
   s.add_runtime_dependency 'rack', '~> 1.1'
   s.add_runtime_dependency 'mongrel', '~> 1.2.0.pre2'
   s.add_runtime_dependency 'haml', '~> 3.0'
   s.add_runtime_dependency 'tilt', '~> 1.3'
   s.add_runtime_dependency 'net-ssh', '~> 2.0'
-  s.add_runtime_dependency 'net-scp', '~> 1.0'
-  
+
   s.add_development_dependency 'rspec', '~> 2.6.0'
   s.add_development_dependency 'rack-test', '~> 0.5'
   s.add_development_dependency 'rake'
   s.add_development_dependency 'builder'
+  s.add_development_dependency 'mocha'
   s.add_development_dependency 'erubis'
   s.add_development_dependency 'compass', '~> 0.10.2'
   s.add_development_dependency 'rdiscount'
@@ -35,4 +35,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'less'
   s.add_development_dependency 'coffee-script', '~> 2.2.0'
   s.add_development_dependency 'RedCloth'
+  s.add_development_dependency 'net-scp'
+  s.add_development_dependency 'net-sftp'
 end

--- a/lib/frank/base.rb
+++ b/lib/frank/base.rb
@@ -223,15 +223,6 @@ module Frank
     Frank.reset
     Frank.root = new_root if new_root
 
-    if %w[publish p].include? ARGV.first
-      begin
-        require 'net/ssh'
-        require 'net/scp'
-      rescue LoadError
-        puts "\033[31mpublish requires the 'net-scp' gem. `gem install net-scp'\033[0m"
-        exit!
-      end
-    end
 
     # setup compass
     begin

--- a/lib/frank/cli.rb
+++ b/lib/frank/cli.rb
@@ -130,7 +130,7 @@ module Frank
         when 'publish', 'p'
           # compile the project and scp it to server
           Frank.publishing!
-          Frank::Publish::SCP.execute!
+          Frank::Publish.execute!
         when 'upgrade'
           # upgrade if we need to upgrade
           Frank.upgrade!

--- a/lib/frank/middleware/statik.rb
+++ b/lib/frank/middleware/statik.rb
@@ -1,7 +1,7 @@
 module Frank
   module Middleware
     class Statik
- 
+
       def initialize(app, options={})
         @app = app
         frank_root = File.expand_path(File.dirname(File.dirname(__FILE__))) + '/templates'
@@ -9,13 +9,13 @@ module Frank
         @frank_server = Rack::File.new(frank_root)
         @static_server = Rack::File.new(root)
       end
- 
+
       # handles serving from __frank__
       # looks for static access, if not found,
       # passes request to frank
       def call(env)
         path = env['PATH_INFO'].dup
- 
+
         if path.include? '__frank__'
           env['PATH_INFO'].gsub!('/__frank__', '')
           result = @frank_server.call(env)
@@ -24,18 +24,18 @@ module Frank
           env['PATH_INFO'] << 'index.html' if path[-1..-1] == '/'
           result = @static_server.call(env)
         end
-      
+
         # return if static assets found
         # else reset the path and pass to frank
-        if result[0] == 200
+        if result[0] == 200 || result[0] == 304
           result
         else
           env['PATH_INFO'] = path
           @app.call(env)
         end
-      
+
       end
-      
+
     end
   end
 end

--- a/lib/frank/publish.rb
+++ b/lib/frank/publish.rb
@@ -1,68 +1,76 @@
 module Frank
   module Publish
 
-    class SCP
-      def self.execute!
-        exit_unless_configured
 
-        unless Frank.silent_export?
-          puts "\nFrank is..."
-          puts " - \033[32mExporting templates\033[0m"
-        end
+    def self.execute!
+      protocol = exit_unless_configured.to_s
 
-        tmp_folder = "/tmp/frankexp-#{Frank.proj_name}"
+      ok_message "", "\nFrank is..."
+      ok_message "Exporting templates", " - "
 
-        # remove stale folder if it exists
-        FileUtils.rm_rf(tmp_folder) if File.exist?(tmp_folder)
+      # upload the files and report progress
+      ok_message "Publishing to: `#{Frank.publish.host}:#{Frank.publish.path}' via #{protocol}", " - "
 
-        # dump the project in production mode to tmp folder
-        Frank.export.path = tmp_folder
-        Frank.export.silent = true
-        Frank::Compile.export!
 
-        puts " - \033[32mPublishing to:\033[0m `#{Frank.publish.host}:#{Frank.publish.path}'" unless Frank.silent_export?
-
-        ssh_options = {
-          :password => Frank.publish.password,
-          :port     => Frank.publish.port
-        }
-
-        current = nil
-
-        # upload the files and report progress
-        Net::SSH.start(Frank.publish.host, Frank.publish.username, ssh_options) do |ssh|
-          ssh.scp.upload!("#{tmp_folder}/", Frank.publish.path, :recursive => true, :chunk_size => 2048) do |ch, name, sent, total|
-
-            puts "   - #{name[tmp_folder.length..-1]}" unless name == current || Frank.silent_export?
-
-            current = name
-          end
-        end
-
-        # cleanup by removing tmp folder
-        FileUtils.rm_rf(tmp_folder)
-
-        puts "\n\033[32mPublish complete!\033[0m" unless Frank.silent_export?
+      req = "frank/publish/#{protocol.downcase}"
+      rescue_load_error protocol do
+        require req
+        clazz = Frank::Publish.const_get(protocol.upcase)
+        publisher = clazz.new(Frank.publish)
+        publisher.perform!
       end
 
-      def self.exit_unless_configured
-        required_settings = { :host => Frank.publish.host, :path => Frank.publish.path, :username => Frank.publish.username }
-        should_exit       = false
-        message           = "\033[31m"
-
-        required_settings.each do |name, value|
-          if value.nil?
-            message << "Frank.publish.#{name} is required to publish. You can configure it in setup.rb\n"
-            exiting = true
-          end
-        end
-
-        message << "\033[0m"
-
-        puts message and exit! if should_exit
-      end
-
+      ok_message "\nPublish complete!"
     end
 
+    def self.exit_unless_configured
+      required_settings = {:host => Frank.publish.host, :path => Frank.publish.path, :username => Frank.publish.username}
+
+      should_exit = false
+      message = ""
+
+      protocol = Frank.publish.mode || :scp
+      unless [:ftp, :ftptls, :sftp, :scp].include?(protocol.to_sym)
+        message << "Frank.publish.mode = #{protocol} is not supported. Supported publish modes are 'ftp', 'ftptls', 'sftp' or 'scp' (default)\n"
+        should_exit = true
+      end
+
+      required_settings.each do |name, value|
+        if value.nil?
+          message << "Frank.publish.#{name} is required to publish. You can configure it in setup.rb\n"
+          should_exit = true
+        end
+      end
+
+
+      if should_exit
+        err_message message
+        exit!
+      end
+
+      protocol
+    end
+
+    def self.rescue_load_error protocol, &blk
+      gem = "net-#{protocol}"
+      begin
+        yield
+      rescue LoadError
+        err_message "Publishing via #{protocol} requires the '#{gem}' gem. `gem install #{gem}'"
+        exit!
+      end
+    end
+
+
+    def self.ok_message str, prefix = ''
+      puts "#{prefix}\033[32m#{str}\033[0m"
+    end
+
+    def self.err_message str, prefix = ''
+      puts "#{prefix}\033[31m#{str}\033[0m"
+    end
+
+
   end
+
 end

--- a/lib/frank/publish/base.rb
+++ b/lib/frank/publish/base.rb
@@ -1,0 +1,94 @@
+module Frank
+  module Publish
+    class Base
+
+      attr_accessor :username, :password
+      attr_accessor :hostname, :port
+      attr_accessor :remote_path
+      attr_accessor :local_path
+
+
+      def initialize(options)
+        @username = options.user || options.username
+        @password = options.password
+        @hostname = options.host
+        @remote_path = options.path
+        @port = options.port
+        @local_path = "/tmp/frank-publish-#{Frank.proj_name}-#{Time.now.to_i}"
+      end
+
+      ##
+      # Performs the backup transfer
+      def perform!
+        export!
+        begin
+          transfer!
+        rescue SocketError
+          err_message "Transfer failed. SocketError. Do you have internet?"
+        end
+        cleanup!
+      end
+
+
+      private
+
+      def export!
+        # remove stale folder if it exists
+        FileUtils.rm_rf(local_path) if File.exist?(local_path)
+
+        # dump the project in production mode to tmp folder
+        Frank.export.path = @local_path
+        Frank.export.silent = true
+        Frank::Compile.export!
+      end
+
+
+      ##
+      # returns a local_path relative list of all files to transfer for this export
+      def files_to_transfer
+        list = []
+        return list unless File.exist?(local_path)
+
+        Dir.chdir(local_path) do
+          list = Dir.glob("**/*").map do |f|
+            f unless File.directory? f
+          end.compact!
+        end
+
+        list
+      end
+
+      ##
+      # returns a local_path relative list of all directories to export
+      def directories
+        list = []
+        return list unless File.exist?(local_path)
+
+        Dir.chdir(local_path) do
+          list = Dir.glob("**/*").map do |f|
+            f if File.directory? f
+          end.compact!
+        end
+
+        list
+      end
+
+      def cleanup!
+        FileUtils.rm_rf(@local_path)
+      end
+
+      # ZOMG, we a need a Logger or sth.
+      def ok_message *args
+        Frank::Publish.ok_message *args
+      end
+
+      def err_message *args
+        Frank::Publish.err_message *args
+      end
+
+
+    end
+
+
+  end
+end

--- a/lib/frank/publish/ftp.rb
+++ b/lib/frank/publish/ftp.rb
@@ -1,0 +1,80 @@
+require 'frank/publish/base'
+require 'net/ftp'
+
+module Frank
+  module Publish
+
+    class FTP < Base
+
+      def initialize(options, &block)
+        super(options)
+        instance_eval(&block) if block_given?
+
+        @port ||= 21
+        @remote_path = remote_path.sub(/^\~\//, '').sub(/^\//, '')
+      end
+
+      private
+
+      ##
+      # Establishes a connection to the remote server
+      #
+      # Note:
+      # Since the FTP port is defined as a constant in the Net::FTP class, and
+      # might be required to change by the user, we dynamically remove and
+      # re-add the constant with the provided port value
+      def connection
+        if Net::FTP.const_defined?(:FTP_PORT)
+          Net::FTP.send(:remove_const, :FTP_PORT)
+        end; Net::FTP.send(:const_set, :FTP_PORT, port)
+
+        Net::FTP.open(hostname, username, password) do |ftp|
+          ftp.passive = true
+          yield ftp
+        end
+      end
+
+      ##
+      # Transfers the archived file to the specified remote server
+      def transfer!
+        connection do |ftp|
+          directories.each do |dir|
+            create_remote_path(File.join(remote_path, dir), ftp)
+          end
+
+          files_to_transfer.each do |file|
+            ok_message "Uploading #{file}", "    - "
+            ftp.put(
+              File.join(local_path, file),
+              File.join(remote_path, file)
+            )
+          end
+        end
+      end
+
+      ##
+      # Creates (if they don't exist yet) all the directories on the remote
+      # server in order to upload the backup file. Net::FTP does not support
+      # paths to directories that don't yet exist when creating new
+      # directories. Instead, we split the parts up in to an array (for each
+      # '/') and loop through that to create the directories one by one.
+      # Net::FTP raises an exception when the directory it's trying to create
+      # already exists, so we have rescue it
+      def create_remote_path(remote_path, ftp)
+        path_parts = []
+        remote_path.split('/').each do |path_part|
+          path_parts << path_part
+          begin
+            dir = path_parts.join('/')
+            ftp.mkdir(dir) unless dir.empty?
+          rescue Net::FTPPermError;
+          end
+        end
+      end
+
+
+    end
+
+
+  end
+end

--- a/lib/frank/publish/ftptls.rb
+++ b/lib/frank/publish/ftptls.rb
@@ -1,0 +1,80 @@
+require 'frank/publish/base'
+require 'net/ftptls'
+
+module Frank
+  module Publish
+
+    class FTPTLS < Base
+
+      def initialize(options, &block)
+        super(options)
+        instance_eval(&block) if block_given?
+
+        @port ||= 21
+        @remote_path = remote_path.sub(/^\~\//, '').sub(/^\//, '')
+      end
+
+      private
+
+      ##
+      # Establishes a connection to the remote server
+      #
+      # Note:
+      # Since the FTP port is defined as a constant in the Net::FTP class, and
+      # might be required to change by the user, we dynamically remove and
+      # re-add the constant with the provided port value
+      def connection
+        if Net::FTPTLS.const_defined?(:FTP_PORT)
+          Net::FTPTLS.send(:remove_const, :FTP_PORT)
+        end; Net::FTPTLS.send(:const_set, :FTP_PORT, port)
+
+        Net::FTPTLS.open(hostname, username, password) do |ftp|
+          ftp.passive = true
+          yield ftp
+        end
+      end
+
+      ##
+      # Transfers the archived file to the specified remote server
+      def transfer!
+        connection do |ftp|
+          directories.each do |dir|
+            create_remote_path(File.join(remote_path, dir), ftp)
+          end
+
+          files_to_transfer.each do |file|
+            ok_message "Uploading #{file}", "    - "
+            ftp.put(
+              File.join(local_path, file),
+              File.join(remote_path, file)
+            )
+          end
+        end
+      end
+
+      ##
+      # Creates (if they don't exist yet) all the directories on the remote
+      # server in order to upload the backup file. Net::FTP does not support
+      # paths to directories that don't yet exist when creating new
+      # directories. Instead, we split the parts up in to an array (for each
+      # '/') and loop through that to create the directories one by one.
+      # Net::FTP raises an exception when the directory it's trying to create
+      # already exists, so we have rescue it
+      def create_remote_path(remote_path, ftp)
+        path_parts = []
+        remote_path.split('/').each do |path_part|
+          path_parts << path_part
+          begin
+            dir = path_parts.join('/')
+            ftp.mkdir(dir) unless dir.empty?
+          rescue Net::FTPPermError;
+          end
+        end
+      end
+
+
+    end
+
+
+  end
+end

--- a/lib/frank/publish/scp.rb
+++ b/lib/frank/publish/scp.rb
@@ -1,0 +1,37 @@
+require 'frank/publish/base'
+require 'net/ssh'
+require 'net/scp'
+
+
+module Frank
+  module Publish
+    class SCP < Base
+
+      def initialize(options, &block)
+        super(options)
+        instance_eval(&block) if block_given?
+
+        @port ||= 22
+      end
+
+
+      def connection
+        Net::SCP.start(hostname, username, :password => password) do |scp|
+          yield scp
+        end
+      end
+
+      def transfer!
+        connection do |scp|
+          old_name = ''
+          scp.upload! local_path, remote_path do |ch, name|
+            if old_name != name
+              ok_message "Uploading #{name}", "    - "
+            end
+          end
+        end
+      end
+
+    end
+  end
+end

--- a/lib/frank/publish/sftp.rb
+++ b/lib/frank/publish/sftp.rb
@@ -1,0 +1,37 @@
+require 'frank/publish/base'
+require 'net/ssh'
+require 'net/sftp'
+
+
+module Frank
+  module Publish
+    class SFTP < Base
+
+      def initialize(options, &block)
+        super(options)
+        instance_eval(&block) if block_given?
+
+        @port ||= 22
+      end
+
+
+      def connection
+        Net::SFTP.start(hostname, username, :password => password) do |scp|
+          yield scp
+        end
+      end
+
+      def transfer!
+        connection do |scp|
+          old_name = ''
+          scp.upload! local_path, remote_path do |ch, name|
+            if old_name != name
+              ok_message "Uploading #{name}", "    - "
+            end
+          end
+        end
+      end
+
+    end
+  end
+end

--- a/lib/frank/publish/shell_scp.rb
+++ b/lib/frank/publish/shell_scp.rb
@@ -1,0 +1,29 @@
+module Frank
+  module Publish
+
+    #TODO
+
+    class ShellSCP
+
+
+      def self.shell_copy(local_dir, remote_dir, options)
+
+        host = []
+        command = ["scp "]
+        command << "-P #{options[:port]} " if options[:port]
+        command << "-r #{local_dir}/* "
+        host << "#{options[:username]}" if options[:username]
+        host << ":#{options[:password]}" if options[:password]
+        host << "@#{options[:host]}:#{remote_dir}"
+
+        shell_command = "#{command.join('')}#{host.join('')}"
+        system(shell_command)
+
+      end
+
+
+    end
+
+
+  end
+end

--- a/lib/frank/settings.rb
+++ b/lib/frank/settings.rb
@@ -43,6 +43,7 @@ module Frank
       @publish.path = nil
       @publish.username = nil
       @publish.password = nil
+      @publish.mode = nil
 
       # setup folders
       @static_folder = "static"

--- a/lib/template/setup.rb
+++ b/lib/template/setup.rb
@@ -53,7 +53,8 @@ Frank.export.path = "exported"
 #  Publish settings:
 #
 #  Frank can publish your exported project to
-#  a server. All you have to do is tell Frank what host, path, and username.
+#  a remote server via scp (default) or ftp. All you have to do is tell Frank what host, path, and username.
+#  Depending on the chosen mode, you may need to install net-scp or net-sftp.
 #  If you have ssh keys setup there is no need for a password.
 #  Just uncomment the Publish settings below and
 #  make the appropriate changes.
@@ -63,6 +64,8 @@ Frank.export.path = "exported"
 #  Frank.publish.username = 'me'
 #  Frank.publish.password = 'secret'
 #  Frank.publish.port = 22
+#  Frank.publish.mode = :scp (or :ftp, :ftptls, :sftp)  #no ftptls in ruby 1.9
+#
 #
 
 # ----------------------

--- a/spec/base_spec.rb
+++ b/spec/base_spec.rb
@@ -1,4 +1,4 @@
-require File.dirname(__FILE__) + '/helper'
+require File.dirname(__FILE__) + '/spec_helper'
 
 describe Frank::Base do
   include Rack::Test::Methods

--- a/spec/base_spec.rb
+++ b/spec/base_spec.rb
@@ -26,14 +26,14 @@ describe Frank::Base do
     get '/'
 
     last_response.should be_ok
-    last_response.body.should == "<div id='p'>/</div>\n<div id='layout'>\n  <h1>hello worlds</h1>\n  <h2>/</h2>\n</div>\n"
+    last_response.body.strip.should == "<div id='p'>/</div>\n<div id='layout'>\n  <h1>hello worlds</h1>\n  <h2>/</h2>\n</div>"
   end
 
   it 'renders a page and uses a helper' do
     get '/helper_test'
 
     last_response.should be_ok
-    last_response.body.should == "<div id='p'>/helper_test</div>\n<div id='layout'>\n  <h1>hello from helper</h1>\n</div>\n"
+    last_response.body.strip.should == "<div id='p'>/helper_test</div>\n<div id='layout'>\n  <h1>hello from helper</h1>\n</div>"
   end
 
   it 'renders a nested template given a request' do
@@ -51,7 +51,7 @@ describe Frank::Base do
   end
 
   it 'renders a 404 page if template not found' do
-    get '/not_here.css'
+    capture_stdout { get '/not_here.css' }
 
     last_response.should_not be_ok
     last_response.content_type.should == 'text/html'
@@ -68,7 +68,7 @@ describe Frank::Base do
   it 'stubs out a project' do
     out = capture_stdout { Frank.stub('stubbed') }
     Dir.entries('stubbed').should == Dir.entries(File.join(LIBDIR, 'template'))
-    response = "\nFrank is...\n - \e[32mCreating\e[0m your project 'stubbed'\n - \e[32mCopying\e[0m Frank template\n\n \e[32mCongratulations, 'stubbed' is ready to go!\e[0m\n"
+    response = "\nFrank is...\n - \e[32mCreating\e[0m your project 'stubbed'\n - \e[32mCopying\e[0m default Frank template\n\n \e[32mCongratulations, 'stubbed' is ready to go!\e[0m\n"
     out.string.should == response
   end
 

--- a/spec/compile_spec.rb
+++ b/spec/compile_spec.rb
@@ -1,4 +1,4 @@
-require File.dirname(__FILE__) + '/helper'
+require File.dirname(__FILE__) + '/spec_helper'
 
 describe Frank::Compile do
   include Rack::Test::Methods
@@ -14,6 +14,8 @@ describe Frank::Compile do
       end
 
       it 'creates the default export dir' do
+        Frank.bootstrap(proj_dir)
+
         Dir.chdir proj_dir do
           frank 'export'
 

--- a/spec/publish/base_spec.rb
+++ b/spec/publish/base_spec.rb
@@ -1,0 +1,125 @@
+# encoding: utf-8
+
+require File.expand_path('../../spec_helper.rb', __FILE__)
+require 'frank/publish/base'
+
+
+describe Frank::Publish::Base do
+
+  let(:publisher) do
+    Frank::Publish::Base.new(Frank.publish)
+  end
+
+  before(:all) do
+    Frank.bootstrap(File.join(File.dirname(__FILE__), '..', 'template'))
+  end
+
+  describe '#initialize' do
+
+    it 'should set the correct values' do
+      publisher.username.should == 'test'
+      publisher.password.should == 'secret'
+      publisher.hostname.should == 'example.com'
+      publisher.remote_path.should == '/remote/path'
+    end
+
+    it 'should set the local export path' do
+      publisher.local_path =~ /\/tmp\/frank-publish-template-\d+\//
+    end
+
+  end
+
+  describe '#permform!' do
+
+    before do
+      publisher.stubs(:export!)
+      publisher.stubs(:transfer!)
+      publisher.stubs(:cleanup!)
+    end
+
+    it 'call export, transfer, cleanup ins that order' do
+      publisher.expects(:export!)
+      publisher.expects(:transfer!)
+      publisher.expects(:cleanup!)
+
+      publisher.perform!
+    end
+
+  end
+
+  describe '#files_to_transfer' do
+
+    it 'should list empty directories if export does not exists' do
+      publisher.send(:files_to_transfer).should be_empty
+    end
+
+    it 'should list all files' do
+      publisher.send(:export!)
+      publisher.send(:files_to_transfer).should have(26).elements
+      publisher.send(:files_to_transfer).should include("500.html")
+      publisher.send(:files_to_transfer).should_not include("files")
+    end
+
+    it 'should not list hidden files beginning with .' do
+      publisher.send(:export!)
+      publisher.send(:files_to_transfer).each do |elem|
+        elem.should_not =~ /^\./
+      end
+    end
+
+    after do
+      publisher.send(:cleanup!)
+    end
+
+  end
+
+  describe '#directories' do
+
+    it 'should list empty directories if export does not exists' do
+      publisher.send(:directories).should be_empty
+    end
+
+    it 'should list all directories' do
+      publisher.send(:export!)
+      publisher.send(:directories).should include("files", "nested", "nested/deeper", "stylesheets")
+    end
+
+    it 'should not list . or ..' do
+      publisher.send(:export!)
+      publisher.send(:directories).should_not include('.', '..')
+    end
+
+    after do
+      publisher.send(:cleanup!)
+    end
+
+  end
+
+  describe '#export!' do
+
+    it 'should export the project to the tmp folder' do
+      publisher.send(:export!)
+
+      publisher.local_path.should =~ /\/tmp\/frank-publish-template-\d+/
+      File.exist?(publisher.local_path).should be_true
+    end
+
+    after do
+      publisher.send(:cleanup!)
+    end
+
+  end
+
+  describe '#cleanup!' do
+
+    it 'should not leave the export folder in the tmp folder' do
+      publisher.send(:export!)
+      publisher.send(:cleanup!)
+
+      publisher.local_path.should =~ /\/tmp\/frank-publish-template-\d+/
+      File.exist?(publisher.local_path).should_not be_true
+    end
+
+  end
+
+end

--- a/spec/publish/ftp_spec.rb
+++ b/spec/publish/ftp_spec.rb
@@ -1,0 +1,143 @@
+# encoding: utf-8
+
+require File.expand_path('../../spec_helper.rb', __FILE__)
+require 'frank/publish/ftp'
+
+describe Frank::Publish::FTP do
+
+  let(:publisher) do
+    Frank::Publish::FTP.new(Frank.publish) do |ftp|
+      ftp.username = 'my_username'
+      ftp.password = 'my_password'
+      ftp.hostname = 'ftp.example.com'
+      ftp.local_path = '/local/path'
+      ftp.remote_path = '/remote/path'
+    end
+  end
+
+  before(:all) do
+    Frank.bootstrap(File.join(File.dirname(__FILE__), 'template'))
+  end
+
+  describe '#initialize' do
+    it 'should set the correct values' do
+      publisher.username.should == 'my_username'
+      publisher.password.should == 'my_password'
+      publisher.hostname.should == 'ftp.example.com'
+      publisher.port.should == 21
+      publisher.local_path.should == '/local/path'
+      publisher.remote_path.should == 'remote/path'
+
+    end
+
+    it 'should remove any preceeding tilde and slash from the path' do
+      publisher = Frank::Publish::FTP.new(Frank.publish) do |ftp|
+        ftp.remote_path = '~/my_backups/path'
+      end
+      publisher.remote_path.should == 'my_backups/path'
+    end
+
+    context 'when setting configuration defaults' do
+
+
+    end # context 'when setting configuration defaults'
+
+  end # describe '#initialize'
+
+  describe '#connection' do
+    let(:connection) { mock }
+
+    it 'should yield a connection to the remote server' do
+      Net::FTP.expects(:open).with(
+        'ftp.example.com', 'my_username', 'my_password'
+      ).yields(connection)
+
+      connection.expects(:passive=).with(true)
+
+      publisher.send(:connection) do |ftp|
+        ftp.should be(connection)
+      end
+    end
+
+    it 'should set the Net::FTP_PORT constant' do
+      publisher.port = 40
+      Net::FTP.expects(:const_defined?).with(:FTP_PORT).returns(true)
+      Net::FTP.expects(:send).with(:remove_const, :FTP_PORT)
+      Net::FTP.expects(:send).with(:const_set, :FTP_PORT, 40)
+
+      Net::FTP.expects(:open)
+      publisher.send(:connection)
+    end
+
+  end # describe '#connection'
+
+  describe '#transfer!' do
+    let(:connection) { mock }
+    let(:package) { mock }
+    let(:files) { ["file1", "file2", "subdir1/file3", "subdir2/file4"] }
+    let(:dirs) { ["subdir1", "subdir2"] }
+    let(:s) { sequence '' }
+
+    before do
+      publisher.stubs(:connection).yields(connection)
+      publisher.stubs(:files_to_transfer).returns(files)
+      publisher.stubs(:directories).returns(dirs)
+    end
+
+    it 'should transfer the files' do
+
+
+      # connection.expects(:chdir).in_sequence(s).with('remote/path')
+
+      #publisher.expects(:directories).in_sequence(s)
+
+      publisher.expects(:create_remote_path).in_sequence(s).with('remote/path/subdir1', connection)
+      publisher.expects(:create_remote_path).in_sequence(s).with('remote/path/subdir2', connection)
+
+      connection.expects(:put).in_sequence(s).with(
+        File.join('/local/path', 'file1'),
+        File.join('remote/path', 'file1')
+      )
+
+      connection.expects(:put).in_sequence(s).with(
+        File.join('/local/path', 'file2'),
+        File.join('remote/path', 'file2')
+      )
+
+      connection.expects(:put).in_sequence(s).with(
+        File.join('/local/path', 'subdir1/file3'),
+        File.join('remote/path', 'subdir1/file3')
+      )
+
+      connection.expects(:put).in_sequence(s).with(
+        File.join('/local/path', 'subdir2/file4'),
+        File.join('remote/path', 'subdir2/file4')
+      )
+
+      publisher.send(:transfer!)
+    end
+  end # describe '#transfer!'
+
+
+  describe '#create_remote_path' do
+    let(:connection) { mock }
+    let(:remote_path) { 'remote/folder/another_folder' }
+    let(:s) { sequence '' }
+
+    context 'while properly creating remote directories one by one' do
+      it 'should rescue any FTPPermErrors and continue' do
+        connection.expects(:mkdir).in_sequence(s).
+          with("remote").raises(Net::FTPPermError)
+        connection.expects(:mkdir).in_sequence(s).
+          with("remote/folder")
+        connection.expects(:mkdir).in_sequence(s).
+          with("remote/folder/another_folder")
+
+        expect do
+          publisher.send(:create_remote_path, remote_path, connection)
+        end.not_to raise_error
+      end
+    end
+  end
+
+end

--- a/spec/publish/ftptls_spec.rb
+++ b/spec/publish/ftptls_spec.rb
@@ -1,0 +1,143 @@
+# encoding: utf-8
+
+require File.expand_path('../../spec_helper.rb', __FILE__)
+require 'frank/publish/ftptls'
+
+describe Frank::Publish::FTPTLS do
+
+  let(:publisher) do
+    Frank::Publish::FTPTLS.new(Frank.publish) do |ftp|
+      ftp.username = 'my_username'
+      ftp.password = 'my_password'
+      ftp.hostname = 'ftp.example.com'
+      ftp.local_path = '/local/path'
+      ftp.remote_path = '/remote/path'
+    end
+  end
+
+  before(:all) do
+    Frank.bootstrap(File.join(File.dirname(__FILE__), 'template'))
+  end
+
+  describe '#initialize' do
+    it 'should set the correct values' do
+      publisher.username.should == 'my_username'
+      publisher.password.should == 'my_password'
+      publisher.hostname.should == 'ftp.example.com'
+      publisher.port.should == 21
+      publisher.local_path.should == '/local/path'
+      publisher.remote_path.should == 'remote/path'
+
+    end
+
+    it 'should remove any preceeding tilde and slash from the path' do
+      publisher = Frank::Publish::FTPTLS.new(Frank.publish) do |ftp|
+        ftp.remote_path = '~/my_backups/path'
+      end
+      publisher.remote_path.should == 'my_backups/path'
+    end
+
+    context 'when setting configuration defaults' do
+
+
+    end # context 'when setting configuration defaults'
+
+  end # describe '#initialize'
+
+  describe '#connection' do
+    let(:connection) { mock }
+
+    it 'should yield a connection to the remote server' do
+      Net::FTPTLS.expects(:open).with(
+        'ftp.example.com', 'my_username', 'my_password'
+      ).yields(connection)
+
+      connection.expects(:passive=).with(true)
+
+      publisher.send(:connection) do |ftp|
+        ftp.should be(connection)
+      end
+    end
+
+    it 'should set the Net::FTP_PORT constant' do
+      publisher.port = 40
+      Net::FTPTLS.expects(:const_defined?).with(:FTP_PORT).returns(true)
+      Net::FTPTLS.expects(:send).with(:remove_const, :FTP_PORT)
+      Net::FTPTLS.expects(:send).with(:const_set, :FTP_PORT, 40)
+
+      Net::FTPTLS.expects(:open)
+      publisher.send(:connection)
+    end
+
+  end # describe '#connection'
+
+  describe '#transfer!' do
+    let(:connection) { mock }
+    let(:package) { mock }
+    let(:files) { ["file1", "file2", "subdir1/file3", "subdir2/file4"] }
+    let(:dirs) { ["subdir1", "subdir2"] }
+    let(:s) { sequence '' }
+
+    before do
+      publisher.stubs(:connection).yields(connection)
+      publisher.stubs(:files_to_transfer).returns(files)
+      publisher.stubs(:directories).returns(dirs)
+    end
+
+    it 'should transfer the files' do
+
+
+      # connection.expects(:chdir).in_sequence(s).with('remote/path')
+
+      #publisher.expects(:directories).in_sequence(s)
+
+      publisher.expects(:create_remote_path).in_sequence(s).with('remote/path/subdir1', connection)
+      publisher.expects(:create_remote_path).in_sequence(s).with('remote/path/subdir2', connection)
+
+      connection.expects(:put).in_sequence(s).with(
+        File.join('/local/path', 'file1'),
+        File.join('remote/path', 'file1')
+      )
+
+      connection.expects(:put).in_sequence(s).with(
+        File.join('/local/path', 'file2'),
+        File.join('remote/path', 'file2')
+      )
+
+      connection.expects(:put).in_sequence(s).with(
+        File.join('/local/path', 'subdir1/file3'),
+        File.join('remote/path', 'subdir1/file3')
+      )
+
+      connection.expects(:put).in_sequence(s).with(
+        File.join('/local/path', 'subdir2/file4'),
+        File.join('remote/path', 'subdir2/file4')
+      )
+
+      publisher.send(:transfer!)
+    end
+  end # describe '#transfer!'
+
+
+  describe '#create_remote_path' do
+    let(:connection) { mock }
+    let(:remote_path) { 'remote/folder/another_folder' }
+    let(:s) { sequence '' }
+
+    context 'while properly creating remote directories one by one' do
+      it 'should rescue any FTPPermErrors and continue' do
+        connection.expects(:mkdir).in_sequence(s).
+          with("remote").raises(Net::FTPPermError)
+        connection.expects(:mkdir).in_sequence(s).
+          with("remote/folder")
+        connection.expects(:mkdir).in_sequence(s).
+          with("remote/folder/another_folder")
+
+        expect do
+          publisher.send(:create_remote_path, remote_path, connection)
+        end.not_to raise_error
+      end
+    end
+  end
+
+end

--- a/spec/publish/scp_spec.rb
+++ b/spec/publish/scp_spec.rb
@@ -1,0 +1,62 @@
+# encoding: utf-8
+
+require File.expand_path('../../spec_helper.rb', __FILE__)
+require 'frank/publish/scp'
+
+describe Frank::Publish::SCP do
+
+  let(:publisher) do
+    Frank::Publish::SCP.new(Frank.publish) do |scp|
+      scp.username = 'my_username'
+      scp.password = 'my_password'
+      scp.hostname = 'scp.example.com'
+      scp.local_path = '/local/path'
+      scp.remote_path = '/remote/path'
+    end
+  end
+
+  before(:all) do
+    Frank.bootstrap(File.join(File.dirname(__FILE__), 'template'))
+  end
+
+  describe '#initialize' do
+    it 'should set the correct values' do
+      publisher.username.should == 'my_username'
+      publisher.password.should == 'my_password'
+      publisher.hostname.should == 'scp.example.com'
+      publisher.port.should == 22
+      publisher.local_path.should == '/local/path'
+      publisher.remote_path.should == '/remote/path'
+
+    end
+
+  end # describe '#initialize'
+
+  describe '#connection' do
+    let(:connection) { mock }
+
+    it 'should yield a connection to the remote server' do
+      Net::SCP.expects(:start).with('scp.example.com', 'my_username', :password => 'my_password').yields(connection)
+
+      publisher.send(:connection) do |scp|
+        scp.should be(connection)
+      end
+    end
+
+  end # describe '#connection'
+
+  describe '#transfer!' do
+    let(:connection) { mock }
+
+    before do
+      publisher.stubs(:connection).yields(connection)
+    end
+
+    it 'should transfer the local_path to remote_path using upload!' do
+      connection.expects(:upload!).with('/local/path', '/remote/path')
+
+      publisher.send(:transfer!)
+    end
+  end # describe '#transfer!'
+
+end

--- a/spec/publish/sftp_spec.rb
+++ b/spec/publish/sftp_spec.rb
@@ -1,0 +1,62 @@
+# encoding: utf-8
+
+require File.expand_path('../../spec_helper.rb', __FILE__)
+require 'frank/publish/sftp'
+
+describe Frank::Publish::SFTP do
+
+  let(:publisher) do
+    Frank::Publish::SFTP.new(Frank.publish) do |scp|
+      scp.username = 'my_username'
+      scp.password = 'my_password'
+      scp.hostname = 'scp.example.com'
+      scp.local_path = '/local/path'
+      scp.remote_path = '/remote/path'
+    end
+  end
+
+  before(:all) do
+    Frank.bootstrap(File.join(File.dirname(__FILE__), 'template'))
+  end
+
+  describe '#initialize' do
+    it 'should set the correct values' do
+      publisher.username.should == 'my_username'
+      publisher.password.should == 'my_password'
+      publisher.hostname.should == 'scp.example.com'
+      publisher.port.should == 22
+      publisher.local_path.should == '/local/path'
+      publisher.remote_path.should == '/remote/path'
+
+    end
+
+  end # describe '#initialize'
+
+  describe '#connection' do
+    let(:connection) { mock }
+
+    it 'should yield a connection to the remote server' do
+      Net::SFTP.expects(:start).with('scp.example.com', 'my_username', :password => 'my_password').yields(connection)
+
+      publisher.send(:connection) do |scp|
+        scp.should be(connection)
+      end
+    end
+
+  end # describe '#connection'
+
+  describe '#transfer!' do
+    let(:connection) { mock }
+
+    before do
+      publisher.stubs(:connection).yields(connection)
+    end
+
+    it 'should transfer the local_path to remote_path using upload!' do
+      connection.expects(:upload!).with('/local/path', '/remote/path')
+
+      publisher.send(:transfer!)
+    end
+  end # describe '#transfer!'
+
+end

--- a/spec/publish_spec.rb
+++ b/spec/publish_spec.rb
@@ -1,23 +1,73 @@
-require File.dirname(__FILE__) + '/helper'
+require File.dirname(__FILE__) + '/spec_helper'
+
 
 describe Frank::Publish do
   include Rack::Test::Methods
   include Frank::Spec::Helpers
 
-    let(:proj_dir) { File.join(File.dirname(__FILE__), 'template') }
+  let(:proj_dir) { File.join(File.dirname(__FILE__), 'template') }
+  let(:protocols) { [:ftp, :ftptls, :sftp, :scp] }
 
-    before :all do
-      Dir.chdir proj_dir do
-        frank 'publish'
+  before(:all) do
+    Frank.bootstrap(proj_dir)
+  end
+
+  describe '#exit_unless_configured' do
+
+    before do
+      Frank.publish.host = 'example.com'
+      Frank.publish.username = 'test'
+    end
+
+    # How do I prohibit SystemExit from really exiting?
+    #
+    #it 'should exit if mandatory username param is missing' do
+    #  Frank.publish.username= nil
+    #
+    #  lambda {
+    #    Frank::Publish.exit_unless_configured
+    #  }.should raise_error(SystemExit)
+    #end
+    #
+    #it 'should exit if mandatory host param is missing' do
+    #  Frank.publish.host= nil
+    #
+    #  lambda {
+    #    Frank::Publish.exit_unless_configured
+    #  }.should raise_error(SystemExit)
+    #end
+
+    it 'should return the publish protocol to use' do
+      protocols.each do |p|
+        Frank.publish.mode = p
+
+        Frank::Publish.exit_unless_configured.should == p
       end
+
     end
 
-    it 'creates the published folder' do
-      File.exist?("/tmp/frankexp-#{proj_dir.split('/').last}").should be_true
-    end
+  end
 
-    after(:all) do
-      #FileUtils.rm_r File.join(File.dirname(__FILE__), 'template/output')
+  describe '#execute!' do
+
+    let(:publisher) { mock }
+
+    it 'should instatiate and call perform! on the appropriate class' do
+      protocols.each do |proto|
+        Frank.publish.mode = proto
+
+        require "frank/publish/#{proto}"
+
+        clazz = Frank::Publish.const_get(proto.to_s.upcase)
+        clazz.stubs(:new).with(Frank.publish).returns(publisher)
+        publisher.expects(:perform!)
+
+        Frank::Publish.execute!
+
+      end
+
     end
+  end
+
 
 end

--- a/spec/render_spec.rb
+++ b/spec/render_spec.rb
@@ -1,4 +1,4 @@
-require File.dirname(__FILE__) + '/helper'
+require File.dirname(__FILE__) + '/spec_helper'
 
 describe Frank::Render do
   include Rack::Test::Methods
@@ -56,7 +56,7 @@ describe Frank::Render do
      template = @app.render('partial_locals_test.haml')
      template.should == "\n<div id='p'>/partial_locals_test</div>\n<div id='layout'>\n  <h1>hello worlds</h1>\n  <h2>/partial_locals_test</h2>\n  <p>hello from local</p>\n</div>\n"
    end
-   
+
    it 'renders less template' do
      template = @app.render('stylesheets/less.less')
      template.should include("#hello-worlds { background: red; }")

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,23 +1,24 @@
 testdir = File.dirname(__FILE__)
 $:.unshift testdir unless $LOAD_PATH.include?(testdir)
 
-require 'bundler'
-Bundler.setup
+require 'rubygems' if RUBY_VERSION < '1.9'
+require 'bundler/setup'
 
 require 'stringio'
 require 'rack/test'
 require 'template/helpers'
 require 'frank'
+require 'frank/publish/base'
 
 module Kernel
- def capture_stdout
-   out = StringIO.new
-   $stdout = out
-   yield
-   return out
- ensure
-   $stdout = STDOUT
- end
+  def capture_stdout
+    out = StringIO.new
+    $stdout = out
+    yield
+    return out
+  ensure
+    $stdout = STDOUT
+  end
 end
 
 module Frank
@@ -36,4 +37,21 @@ module Frank
       end
     end
   end
+end
+
+module Frank
+  module Publish
+    def self.ok_message str, prefix = "";
+    end
+
+    def self.err_message str, prefix = "";
+    end
+  end
+end
+
+RSpec.configure do |config|
+  ##
+  # Use Mocha to mock with RSpec
+  config.mock_with :mocha
+
 end

--- a/spec/template/setup.rb
+++ b/spec/template/setup.rb
@@ -1,4 +1,5 @@
 Frank.environment = :test
-Frank.publish.path = '/tmp'
-Frank.publish.host = 'linda'
-Frank.publish.user = 'badmin'
+Frank.publish.path = '/remote/path'
+Frank.publish.host = 'example.com'
+Frank.publish.user = 'test'
+Frank.publish.password = 'secret'

--- a/spec/template_helpers_spec.rb
+++ b/spec/template_helpers_spec.rb
@@ -1,4 +1,4 @@
-require File.dirname(__FILE__) + '/helper'
+require File.dirname(__FILE__) + '/spec_helper'
 
 describe Frank::TemplateHelpers do
   include Rack::Test::Methods
@@ -27,12 +27,12 @@ describe Frank::TemplateHelpers do
     template = @app.render('refresh.haml')
     template.should include("<script type=\"text/javascript\">\n            (function(){")
   end
-  
+
   it 'renders content_for haml in the layout' do
     template = @app.render('content_for_haml.haml')
     template.should == "<meta foo='content' />\n<div id='p'>/content_for_haml</div>\n<div id='layout'>\n  \n</div>\n"
   end
-  
+
   it 'renders content_for erb in the layout' do
     template = @app.render('content_for_erb.erb')
     template.should == "  <meta foo='content' />\n<div id='p'>/content_for_erb</div>\n<div id='layout'>\n  \n</div>\n"
@@ -84,7 +84,7 @@ describe Frank::TemplateHelpers do
     it 'render image url using imager' do
       template = @app.render('lorem_test.haml')
       reg1 = /<img src='http:\/\/placehold\.it\/400x300' \/>/
-      reg2 = /<img src='http:\/\/placehold\.it\/400x300\/[a-z0-9]{6}\/[a-z0-9]{6}' \/>/      
+      reg2 = /<img src='http:\/\/placehold\.it\/400x300\/[a-z0-9]{6}\/[a-z0-9]{6}' \/>/
       reg3 = /<img src='http:\/\/placehold\.it\/400x300\/444\/eee' \/>/
       reg4 = /<img src='http:\/\/placehold\.it\/400x300\/ccc\/aaa' \/>/
       reg5 = /<img src='http:\/\/placehold\.it\/400x300\/444(&amp;|&)text=blah' \/>/


### PR DESCRIPTION
This adds a new parameter `Frank.publish.mode` to select between the publishing solutions. So far you can select between `scp`, `sftp`, `ftp` or `ftptls`. The latter is only supported for ruby < 1.9. 

The default way of publishing is still scp over ssh. The origininal staticness of Frank::Publish is still somewhat achy, but hey - it works and is reasonably well tested. SFTP and FTPTLS were quickly added by cut and paste. this should probably be refactored at some point. 

I have added a simple rake task, so don't need to autotest if just want to test & build the gem -  which I ran into first after cloning the repo.

Hope you like it.
