### PR TITLE
Two auto_refresh extensions

### DIFF
--- a/lib/frank/base.rb
+++ b/lib/frank/base.rb
@@ -269,7 +269,13 @@ module Frank
 
     builder = Rack::Builder.new do
       use Frank::Middleware::Statik, :root => Frank.static_folder
-      use Frank::Middleware::Refresh, :watch => [ Frank.dynamic_folder, Frank.static_folder, Frank.layouts_folder ]
+      watch_dirs = [ Frank.dynamic_folder, Frank.static_folder, Frank.layouts_folder ]
+      unless ENV['FRANK_REFRESH_DIRS'].nil?
+        watch_dirs.concat ENV['FRANK_REFRESH_DIRS'].split(/,/) unless ENV['FRANK_REFRESH_DIRS'].nil?
+        watch_dirs.uniq!
+        puts "Watching directories #{watch_dirs.join(', ')}"
+      end
+      use Frank::Middleware::Refresh, :watch => watch_dirs
       run base
     end
 

--- a/lib/frank/template_helpers.rb
+++ b/lib/frank/template_helpers.rb
@@ -53,8 +53,16 @@ module Frank
             function addLoadingIndicator() {
               var body = document.getElementsByTagName("body")[0]
               var div = document.createElement('div')
-              div.innerHTML = 'Change detected. Reloading. Please wait ...'
-              div.setAttribute('style', 'z-index: 1000; position: fixed; top: 0; right: 40%; background: #901010; font-weight: bold; color: white; font-size: 16px; text-align: center; padding-top: 10px; width: 400px; font-family: sans; height: 30px; opacity: 0.8; border: 1px solid #601010')
+              div.innerHTML = '<p style="margin: 2px 0; padding: 2px 0"><div style="cursor: pointer; background: #f00; color: #faa;' + 
+                                             'float: right; margin-right: 5px;width: 1em; height; 1ex"' + 
+                                      'onclick="this.parentNode.style.display=\\'none\\'; return false">x</div>' + 
+                                  'Change detected at ' + new Date() +
+                              '</p><p style="margin: 2px 0; padding: 2px 0">Reloading. Please wait ...</p>'
+              div.setAttribute('style', 'z-index: 1000; position: fixed; top: 0; right: 40%;width: 400px; height: 100px;' +
+                                        'background: #308030; color: white; opacity: 0.8; ' +
+                                        'font-family: sans; font-weight: bold; font-size: 16px;' +
+                                        'text-align: center; padding: 2px 5px 5px 5px' +
+                                        'border: 1px solid #104010')
               body.appendChild(div)
             }
 

--- a/lib/frank/template_helpers.rb
+++ b/lib/frank/template_helpers.rb
@@ -56,13 +56,13 @@ module Frank
               div.innerHTML = '<p style="margin: 2px 0; padding: 2px 0"><div style="cursor: pointer; background: #f00; color: #faa;' + 
                                              'float: right; margin-right: 5px;width: 1em; height; 1ex"' + 
                                       'onclick="this.parentNode.style.display=\\'none\\'; return false">x</div>' + 
-                                  'Change detected at ' + new Date() +
+                                  'Frank has detected changes at ' + new Date() +
                               '</p><p style="margin: 2px 0; padding: 2px 0">Reloading. Please wait ...</p>'
-              div.setAttribute('style', 'z-index: 1000; position: fixed; top: 0; right: 40%;width: 400px; height: 100px;' +
+              div.setAttribute('style', 'z-index: 1000; position: fixed; top: 0; right: 40%;width: 460px; height: 110px;' +
                                         'background: #308030; color: white; opacity: 0.8; ' +
                                         'font-family: sans; font-weight: bold; font-size: 16px;' +
                                         'text-align: center; padding: 2px 5px 5px 5px' +
-                                        'border: 1px solid #104010')
+                                        'border: 10px solid #104010')
               body.appendChild(div)
             }
 
@@ -85,7 +85,7 @@ module Frank
               };
               req.open('GET', '/__refresh__', true);
               req.send( null );
-              if (!loading)
+              if (!loading && !window.stop_refresh_check)
                 setTimeout( arguments.callee, 1000 );
             })();
 

--- a/lib/frank/template_helpers.rb
+++ b/lib/frank/template_helpers.rb
@@ -49,10 +49,22 @@ module Frank
           <script type="text/javascript">
           (function(){
             var when = #{Time.now.to_i};
+            var loading = false
+            function addLoadingIndicator() {
+              var body = document.getElementsByTagName("body")[0]
+              var div = document.createElement('div')
+              div.innerHTML = 'Change detected. Reloading. Please wait ...'
+              div.setAttribute('style', 'z-index: 1000; position: fixed; top: 0; right: 40%; background: #901010; font-weight: bold; color: white; font-size: 16px; text-align: center; padding-top: 10px; width: 400px; font-family: sans; height: 30px; opacity: 0.8; border: 1px solid #601010')
+              body.appendChild(div)
+            }
 
             function process( raw ){
               if( parseInt(raw) > when ) {
-                window.location.reload();
+                if (!loading) {
+                  loading = true
+                  addLoadingIndicator();
+                  window.location.reload();
+                }
               }
             }
             
@@ -65,7 +77,8 @@ module Frank
               };
               req.open('GET', '/__refresh__', true);
               req.send( null );
-              setTimeout( arguments.callee, 1000 );
+              if (!loading)
+                setTimeout( arguments.callee, 1000 );
             })();
 
           })();

--- a/spec/template_helpers_spec.rb
+++ b/spec/template_helpers_spec.rb
@@ -27,6 +27,16 @@ describe Frank::TemplateHelpers do
     template = @app.render('refresh.haml')
     template.should include("<script type=\"text/javascript\">\n            (function(){")
   end
+
+  it 'should have provision for a loading indicator in the refresh javascript' do
+    template = @app.render('refresh.haml')
+    template.should include("addLoadingIndicator()")
+  end
+
+  it 'should have provision for stopping automatic refresh in the refresh javascript' do
+    template = @app.render('refresh.haml')
+    template.should include("!window.stop_refresh_check")
+  end
   
   it 'renders content_for haml in the layout' do
     template = @app.render('content_for_haml.haml')


### PR DESCRIPTION
Hey, I use frank for turning results of my computations into HTML which I look at in my browser.

I put computation code in the lib directory, and place display in dynamic templates. I work by making small changes to the inputs, or extend the computation code. The auto_refresh feature makes it so that a file-save becomes similar to a "return" in a terminal: the results of the computation, from new code or display-changes, show up in my browser immediately.

This works all very nice. I ran into two issues though, and am submitting the changes that fix them:
1. The watch_dir which is used for Frank::Middleware::Refresh did not allow any configuration (couldn't watch for changes in my lib directory)
2. When computations take a while (>20 sec), the auto_refresh javascript would send multiple refresh requests.

For (1) I allowed configuration by reading an environment variable "FRANK_REFRESH_DIRS" the contents of which are appended to the "watch_dirs" variable

For (2) I added a javascript variable "loading" which is set when the page is reloaded, and prevents any further reloads. While the new page is loading, a more-or-less fancy loading indicator section is displayed on the page. Automatic refresh can be disabled through simple javascript "window.stop_refresh_check = true"

Spec changes cover (2). Couldn't find a way to add specs for (1). Might be better to provide for a hook to use in setup.rb (Frank::Middleware::Refresh.add_watch_directory 'lib') anyway

Cheers!
