### PR TITLE
change glob in compile to prevent building twice

### DIFF
--- a/lib/frank/compile.rb
+++ b/lib/frank/compile.rb
@@ -11,7 +11,7 @@ module Frank
       def compile_templates
         dir = File.join(Frank.root, Frank.dynamic_folder)
 
-        Dir[File.join(dir, '**{,/*/**}/*')].each do |path|
+        Dir[File.join(dir, '**{,/*/**/*}')].each do |path|
           if File.file?(path) && !File.basename(path).match(/^(\.|_)/)
             path    = path[ (dir.size + 1)..-1 ]
             ext     = File.extname(path)


### PR DESCRIPTION
Noticed that Frank was building everything twice, tracked it down to the file matching in compile.

Symlinks still work as far as I can tell (don't use them in any projects so I just made a quick test case), and the Mailchimp site still builds fine.
